### PR TITLE
[FEAT] simple-jwt를 활용하여 회원가입, 로그인, 로그아웃 기능 구현

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,11 +1,44 @@
+import uuid
+
+from django.contrib.auth.base_user import BaseUserManager, AbstractBaseUser
 from django.db import models
 
 
-# Create your models here.
-class Users(models.Model):
-    uuid = models.UUIDField(primary_key=True)
+class UserManager(BaseUserManager):
+    def create_user(self, nickname, password=None):
+        if not nickname:
+            raise ValueError('Users Must Have a nickname')
+
+        user = self.model(nickname=nickname)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, nickname, password):
+        if password is None:
+            raise TypeError('Superusers must have a password.')
+
+        user = self.create_user(nickname, password)
+        user.is_superuser = True
+        user.is_staff = True
+        user.save()
+
+        return user
+
+
+class Users(AbstractBaseUser):
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     password = models.CharField(null=False, max_length=50)
-    nickname = models.CharField(null=False, max_length=50)
+    nickname = models.CharField(null=False, max_length=50, unique=True)
+
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    is_superuser = models.BooleanField(default=False)
+
+    objects = UserManager()
 
     def __str__(self):
         return self.uuid
+
+    class Meta:
+        db_table = "users"

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -28,7 +28,7 @@ class UserManager(BaseUserManager):
 
 class Users(AbstractBaseUser):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    password = models.CharField(null=False, max_length=50)
+    password = models.CharField(null=False, max_length=128)
     nickname = models.CharField(null=False, max_length=50, unique=True)
 
     is_active = models.BooleanField(default=True)

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,38 @@
+import uuid
+
+from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+from accounts.models import Users
+
+
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+
+        # Add custom claims
+        token['uuid'] = str(user.uuid)
+        token['nickname'] = user.nickname
+
+        return token
+
+
+class UserSerializer(serializers.ModelSerializer):
+    uuid = serializers.UUIDField()
+    nickname = serializers.JSONField()
+    password = serializers.JSONField()
+
+    class Meta:
+        model = Users
+        fields = '__all__'
+
+    def create(self, validated_data):
+        return Users.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        instance.uuid = validated_data.get('uuid', instance.uuid)
+        instance.password = validated_data.get('password', instance.password)
+        instance.nickname = validated_data.get('nickname', instance.nickname)
+        instance.save()
+        return instance

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenVerifyView, TokenRefreshView
 
-from accounts.views import RegisterAPIView
+from accounts.views import RegisterAPIView, UserLoginAPIView
 
 urlpatterns = [
     path("register/", RegisterAPIView.as_view(), name='user_register'),
+    path('login/', UserLoginAPIView.as_view(), name='user_login'),
     # path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     # path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     # path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,8 +1,11 @@
-from django.urls import path
-from accounts import views
+from django.urls import path, include
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenVerifyView, TokenRefreshView
 
+from accounts.views import RegisterAPIView
 
 urlpatterns = [
-    # path('login/', views.login),
-    # path('logout/', views.logout)
+    path("register/", RegisterAPIView.as_view(), name='user_register'),
+    # path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    # path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+    # path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenVerifyView, TokenRefreshView
 
-from accounts.views import RegisterAPIView, UserLoginAPIView
+from accounts.views import RegisterAPIView, UserLoginAPIView, UserLogoutAPIView
 
 urlpatterns = [
     path("register/", RegisterAPIView.as_view(), name='user_register'),
     path('login/', UserLoginAPIView.as_view(), name='user_login'),
+    path('logout/', UserLogoutAPIView.as_view(), name='user_logout'),
     # path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     # path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     # path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,98 @@
-from django.shortcuts import render
+import uuid
 
-# Create your views here.
+from django.contrib.auth.hashers import check_password
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from accounts.models import Users
+from accounts.serializers import UserSerializer, MyTokenObtainPairSerializer
+
+
+# 로그인 뷰
+class UserLoginAPIView(APIView):
+    def post(self, request):
+        nickname = request.data['username']
+        password = request.data['password']
+
+        user = Users.objects.filter(nickname=nickname).first()
+
+        if not user:
+            return Response(
+                {"message": "존재하지 않는 아이디입니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if not check_password(password, user.password):
+            return Response(
+                {"message": "비밀번호가 틀렸습니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if user is not None:
+            token = MyTokenObtainPairSerializer.get_token(user)  # refresh 토큰 생성
+            refresh_token = str(token)  # refresh 토큰 문자열화
+            access_token = str(token.access_token)  # access 토큰 문자열화
+            response = Response(
+                {
+                    "user": UserSerializer(user).data,
+                    "message": "login success",
+                    "jwt_token": {
+                        "access_token": access_token,
+                        "refresh_token": refresh_token
+                    },
+                },
+                status=status.HTTP_200_OK
+            )
+
+            response.set_cookie("access_token", access_token, httponly=True)
+            response.set_cookie("refresh_token", refresh_token, httponly=True)
+            return response
+        else:
+            return Response(
+                {"message": "로그인에 실패하였습니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+
+# 회원가입 뷰
+class RegisterAPIView(APIView):
+    def post(self, request):
+        nickname = request.data.get('nickname')
+
+        if Users.objects.filter(nickname=nickname).exists():
+            return Response(
+                {"message": "이미 존재하는 닉네임입니다."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        user_uuid = uuid.uuid4()
+        user_data = {
+            "uuid": user_uuid,
+            "nickname": request.data.get('nickname'),
+            "password": request.data.get('password'),
+        }
+        serializer = UserSerializer(data=user_data)
+
+        if serializer.is_valid():
+            user = serializer.save()
+
+            token = MyTokenObtainPairSerializer.get_token(user)
+            refresh_token = str(token)
+            access_token = str(token.access_token)
+            res = Response(
+                {
+                    "user": {
+                        "uuid": user.uuid,
+                        "nickname": user.nickname,
+                        "password": user.password,
+                    },
+                    "message": "회원가입 성공",
+                    "token": {
+                        "access": access_token,
+                        "refresh": refresh_token,
+                    },
+                },
+                status=status.HTTP_200_OK
+            )
+            res.set_cookie("access", access_token, httponly=True)
+            res.set_cookie("refresh", refresh_token, httponly=True)
+            return res
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/boards/models.py
+++ b/boards/models.py
@@ -15,6 +15,9 @@ class Category(models.Model):
     def __str__(self):
         return self.id
 
+    class Meta:
+        db_table = "category"
+
 
 class Board(models.Model):
     uuid = models.UUIDField(primary_key=True)
@@ -30,6 +33,9 @@ class Board(models.Model):
     def __str__(self):
         return self.uuid
 
+    class Meta:
+        db_table = "board"
+
 
 class Comment(models.Model):
     uuid = models.UUIDField(primary_key=True)
@@ -42,3 +48,6 @@ class Comment(models.Model):
 
     def __str__(self):
         return self.uuid
+
+    class Meta:
+        db_table = "comment"

--- a/config/settings.py
+++ b/config/settings.py
@@ -9,7 +9,7 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
-
+from datetime import timedelta
 from pathlib import Path
 import os
 
@@ -33,6 +33,21 @@ DEBUG = os.getenv('DEBUG')
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '*']
 
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    )
+}
+
+SIMPLE_JWT = {
+    "TOKEN_OBTAIN_SERIALIZER": "backend-onboarding.serializers.MyTokenObtainPairSerializer",
+    "USER_ID_FIELD": "uuid",  # 기본 키를 uuid로 변경
+    "USER_ID_CLAIM": "user_id",  # JWT에서 기본 사용자 식별 클레임 이름 설정
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),  # 토큰 만료 시간 (선택 사항)
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),    # 리프레시 토큰 만료 시간 (선택 사항)
+}
+
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -45,6 +60,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'accounts',
     'boards',
+    'rest_framework_simplejwt',
 ]
 
 MIDDLEWARE = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,9 +17,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+
 urlpatterns = [
     # TO-DO: CBV로 수정하기
-    path('/', include('accounts.urls')),
+    path('accounts/', include('accounts.urls')),
     path('admin/', admin.site.urls),
     path('boards/', include('boards.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python-dotenv==1.0.1
 sqlparse==0.5.3
 tomli==2.2.1
 typing_extensions==4.12.2
+djangorestframework-simplejwt==5.3.1


### PR DESCRIPTION
## 작업 사항
### 1. simple-jwt 세팅
- settings.py에 jwt 세팅 추가
- 기존에 존재하는 토큰의 시리얼라이저와 작성한 DB 모델이 서로 다르기 때문에 토큰 시리얼라이저를 커스텀하였습니다.

### 2. 회원가입, 로그인, 로그아웃 기능 구현
- 유저 아이디의 역할을 하는 nickname, 비밀번호를 입력받아 회원가입, 로그인 기능을 구현하였습니다. 
- uuid는 유효한 request가 들어왔을 때 생성되고, 비밀번호는 해싱된 채로 DB에 저장됩니다.

<img src="https://github.com/user-attachments/assets/180c81f7-b0b4-4f6c-9880-29f0780a45e3" width="700" height="500">
<img src="https://github.com/user-attachments/assets/f7006420-5d44-47b1-931b-095890435ce9" width="700" height="500">
